### PR TITLE
Period Model: add $interval to $this->interval

### DIFF
--- a/src/Services/Period.php
+++ b/src/Services/Period.php
@@ -47,6 +47,8 @@ class Period
      */
     public function __construct($interval = 'month', $count = 1, $start = '')
     {
+        $this->interval = $interval;
+
         if (empty($start)) {
             $this->start = now();
         } elseif (! $start instanceof Carbon) {


### PR DESCRIPTION
The constructor is not taking the parameter ```$interval``` to its property ```$this->interval```. 