### PR TITLE
Remove unmaintained dependancy on rinvex/laravel-support and depend on spatie/laravel-translatable directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@
     php artisan rinvex:migrate:subscriptions
     ```
 
-3. Done!
+3. **Optional** if you want to change the configurations:
+    ```shell
+    php artisan rinvex:publish:subscriptions
+    ```
+
+4. Done!
 
 
 ## Usage

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,7 +37,7 @@
         <env name="APP_ENV" value="testing" />
         <env name="CACHE_DRIVER" value="array" />
         <env name="SESSION_DRIVER" value="array" />
-        <env name="QUEUE_DRIVER" value="sync" />
+        <env name="QUEUE_CONNECTION" value="sync" />
         <env name="DB_CONNECTION" value="sqlite" />
         <env name="DB_DATABASE" value=":memory:" />
     </php>


### PR DESCRIPTION
Hi,

This is a fix to `spatie/laravel-translatable` unnecessary wraping, instead of using a trait in `rinvex/laravel-support` we directly override its methods in the model.

This also fixes #46 