### PR TITLE
Fixed Subscription Query Error

### DIFF
--- a/database/migrations/03_create_plan_subscriptions_table.php.stub
+++ b/database/migrations/03_create_plan_subscriptions_table.php.stub
@@ -31,7 +31,6 @@ class CreatePlanSubscriptionsTable extends Migration
             $table->softDeletes();
 
             // Indexes
-            $table->unique('slug');
             $table->foreign('plan_id')->references('id')->on(config('rinvex.subscriptions.tables.plans'))
                   ->onDelete('cascade')->onUpdate('cascade');
         });

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -150,7 +150,7 @@ class PlanSubscription extends Model
         $this->setRules([
             'name' => 'required|string|max:150',
             'description' => 'nullable|string|max:10000',
-            'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_subscriptions').',slug',
+            'slug' => 'required|alpha_dash|max:150',
             'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
             'user_id' => 'required|integer',
             'user_type' => 'required|string',
@@ -186,7 +186,8 @@ class PlanSubscription extends Model
         return SlugOptions::create()
                           ->doNotGenerateSlugsOnUpdate()
                           ->generateSlugsFrom('name')
-                          ->saveSlugsTo('slug');
+                          ->saveSlugsTo('slug')
+                          ->allowDuplicateSlugs();
     }
 
     /**


### PR DESCRIPTION
- Added the allow duplicates option to the Subscription Model
- Removed the Unique Index to the Subscription Table

This enables the User to run `$user->subscription('main')` instead of `$user->subscription('main-1')`