### PR TITLE
Change used from smallInteger to bigInteger

### DIFF
--- a/database/migrations/2020_01_01_000004_create_plan_subscription_usage_table.php
+++ b/database/migrations/2020_01_01_000004_create_plan_subscription_usage_table.php
@@ -18,7 +18,7 @@ class CreatePlanSubscriptionUsageTable extends Migration
             $table->bigIncrements('id');
             $table->bigInteger('subscription_id')->unsigned();
             $table->bigInteger('feature_id')->unsigned();
-            $table->smallInteger('used')->unsigned();
+            $table->bigInteger('used')->unsigned();
             $table->dateTime('valid_until')->nullable();
             $table->string('timezone')->nullable();
             $table->timestamps();


### PR DESCRIPTION
Change used from smallInteger to bigInteger. For some case, the usage may reach to 10 numbers, so 5 numbers is not enough to use.