### PR TITLE
[Proposal] Use tag to identify models instead of slug

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -29,7 +29,6 @@ enabled:
   - ternary_to_null_coalescing
   - escape_implicit_backslashes
   - fully_qualified_strict_types
-  - phpdoc_return_self_reference
   - no_null_property_initialization
   - multiline_comment_opening_closing
   - not_operator_with_successor_space

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,4 @@
+risky: true
 preset: recommended
 
 enabled:

--- a/README.md
+++ b/README.md
@@ -8,14 +8,46 @@
 [![StyleCI](https://styleci.io/repos/93313402/shield)](https://styleci.io/repos/93313402)
 [![License](https://img.shields.io/packagist/l/rinvex/laravel-subscriptions.svg?label=License&style=flat-square)](https://github.com/rinvex/laravel-subscriptions/blob/develop/LICENSE)
 
+## Table of Contents
 
-## Considerations
+<details><summary>Click to expand</summary><p>
+
+- [Considerations](#considerations)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Add Subscriptions to User model](#add-subscription)
+  - [Create Plan](#create-plan)
+  - [Get Plan details](#get-plan-details)
+  - [Get Feature value](#get-feature-value)
+  - [Create a Subscription](#create-subscription)
+  - [Change the Plan](#change-plan)
+  - [Feature options](#feature-options)
+  - [Subscription Feature Usage](#subscription-feature-usage)
+  - [Record Feature Usage](#record-feature-usage)
+  - [Reduce Feature Usage](#reduce-feature-usage)
+  - [Check Subscription Status](#check-subscription-status)
+  - [Renew a Subscription](#renew-subscription)
+  - [Cancel a Subscription](#cancel-subscription)
+  - [Scopes](#scopes)
+    - [Subscription model](#subscription-model)
+  - [Models](#models)
+- [Migrating versions](#migrating)
+  - [v4.x to v5.x](#migrating-4-to-5)
+- [Changelog](#changelog)
+- [Support](#support)
+- [Contributing and protocols](#contributing-protocols)
+- [About Rinvex](#about-rinvex)
+- [License](#license)
+</p>
+</details>
+
+## Considerations<a name="considerations"></a>
 
 - Payments are out of scope for this package.
 - You may want to extend some of the core models, in case you need to override the logic behind some helper methods like `renew()`, `cancel()` etc. E.g.: when cancelling a subscription you may want to also cancel the recurring payment attached.
 
 
-## Installation
+## Installation<a name="installation"></a>
 
 1. Install the package via composer:
     ```shell
@@ -35,9 +67,9 @@
 4. Done!
 
 
-## Usage
+## Usage<a name="usage"></a>
 
-### Add Subscriptions to User model
+### Add Subscriptions to User model<a name="add-subscription"></a>
 
 **Rinvex Subscriptions** has been specially made for Eloquent and simplicity has been taken very serious as in any other Laravel related aspect. To add Subscription functionality to your User model just use the `\Rinvex\Subscriptions\Traits\HasSubscriptions` trait like this:
 
@@ -55,10 +87,11 @@ class User extends Authenticatable
 
 That's it, we only have to use that trait in our User model! Now your users may subscribe to plans.
 
-### Create a Plan
+### Create a Plan<a name="create-plan"></a>
 
 ```php
 $plan = app('rinvex.subscriptions.plan')->create([
+    'tag' => 'pro',
     'name' => 'Pro',
     'description' => 'Pro plan',
     'price' => 9.99,
@@ -73,14 +106,14 @@ $plan = app('rinvex.subscriptions.plan')->create([
 
 // Create multiple plan features at once
 $plan->features()->saveMany([
-    new PlanFeature(['name' => 'listings', 'value' => 50, 'sort_order' => 1]),
-    new PlanFeature(['name' => 'pictures_per_listing', 'value' => 10, 'sort_order' => 5]),
-    new PlanFeature(['name' => 'listing_duration_days', 'value' => 30, 'sort_order' => 10, 'resettable_period' => 1, 'resettable_interval' => 'month']),
-    new PlanFeature(['name' => 'listing_title_bold', 'value' => 'Y', 'sort_order' => 15])
+    new PlanFeature(['tag' => 'listings', 'name' => 'Listings', 'description' => 'Number of house listings', 'value' => 50, 'sort_order' => 1]),
+    new PlanFeature(['tag' => 'pictures_per_listing', 'name' => 'Pictures per listing', 'description' => 'Amount of pictures each of your house can have', 'value' => 10, 'sort_order' => 5]),
+    new PlanFeature(['tag' => 'listing_duration_days', 'name' => 'Listing duration', 'description' => 'Duration of your listing (in days)', 'value' => 30, 'sort_order' => 10, 'resettable_period' => 1, 'resettable_interval' => 'month']),
+    new PlanFeature(['tag' => 'listing_title_bold', 'name' => 'Bold title', 'description' => 'Get more views with a bold title!', 'value' => 'Y', 'sort_order' => 15])
 ]);
 ```
 
-### Get Plan Details
+### Get Plan details<a name="get-plan-details"></a>
 
 You can query the plan for further details, using the intuitive API as follows:
 
@@ -105,22 +138,22 @@ $plan->hasGrace();
 
 Both `$plan->features` and `$plan->subscriptions` are collections, driven from relationships, and thus you can query these relations as any normal Eloquent relationship. E.g. `$plan->features()->where('name', 'listing_title_bold')->first()`.
 
-### Get Feature Value 
+### Get Feature value<a name="get-feature-value"></a>
 
 Say you want to show the value of the feature _pictures_per_listing_ from above. You can do so in many ways:
 
 ```php
 // Use the plan instance to get feature's value
-$amountOfPictures = $plan->getFeatureByName('pictures_per_listing')->value;
+$amountOfPictures = $plan->getFeatureByTag('pictures_per_listing')->value;
 
 // Query the feature itself directly
-$amountOfPictures = app('rinvex.subscriptions.plan_feature')->where('name', 'pictures_per_listing')->first()->value;
+$amountOfPictures = app('rinvex.subscriptions.plan_feature')->where('tag', 'pictures_per_listing')->first()->value;
 
 // Get feature value through the subscription instance
 $amountOfPictures = app('rinvex.subscriptions.plan_subscription')->find(1)->getFeatureValue('pictures_per_listing');
 ```
 
-### Create a Subscription
+### Create a Subscription<a name="create-subscription"></a>
 
 You can subscribe a user to a plan by using the `newSubscription()` function available in the `HasSubscriptions` trait. First, retrieve an instance of your subscriber model, which typically will be your user model and an instance of the plan your user is subscribing to. Once you have retrieved the model instance, you may use the `newSubscription` method to create the model's subscription.
 
@@ -128,12 +161,12 @@ You can subscribe a user to a plan by using the `newSubscription()` function ava
 $user = User::find(1);
 $plan = app('rinvex.subscriptions.plan')->find(1);
 
-$user->newSubscription('main', $plan);
+$user->newSubscription('main', $plan, 'Main subscription');
 ```
 
-The first argument passed to `newSubscription` method should be the title of the subscription. If your application offer a single subscription, you might call this `main` or `primary`. The second argument is the plan instance your user is subscribing to.
+The first argument passed to `newSubscription` method should be the identifier tag of the subscription. If your application offer a single subscription, you might call this `main` or `primary`. The second argument is the plan instance your user is subscribing to and the third argument is a human readable name for your subscription.
 
-### Change the Plan
+### Change the Plan<a name="change-plan"></a>
 
 You can change subscription plan easily as follows:
 
@@ -147,19 +180,19 @@ $subscription->changePlan($plan);
 
 If both plans (current and new plan) have the same billing frequency (e.g., `invoice_period` and `invoice_interval`) the subscription will retain the same billing dates. If the plans don't have the same billing frequency, the subscription will have the new plan billing frequency, starting on the day of the change and _the subscription usage data will be cleared_. Also if the new plan has a trial period and it's a new subscription, the trial period will be applied.
 
-### Feature Options
+### Feature Options<a name="feature-options"></a>
 
-Plan features are great for fine tuning subscriptions, you can topup certain feature for X times of usage, so users may then use it only for that amount. Features also have the ability to be resettable and then it's usage could be expired too. See the following examples:
+Plan features are great for fine-tuning subscriptions, you can top up certain feature for X times of usage, so users may then use it only for that amount. Features also have the ability to be resettable and then it's usage could be expired too. See the following examples:
 
 ```php
 // Find plan feature
-$feature = app('rinvex.subscriptions.plan_feature')->where('name', 'listing_duration_days')->first();
+$feature = app('rinvex.subscriptions.plan_feature')->where('tag', 'listing_duration_days')->first();
 
 // Get feature reset date
 $feature->getResetDate(new \Carbon\Carbon());
 ```
 
-### Subscription Feature Usage
+### Subscription Feature Usage<a name="subscription-feature-usage"></a>
 
 There's multiple ways to determine the usage and ability of a particular feature in the user subscription, the most common one is `canUseFeature`:
 
@@ -173,7 +206,7 @@ The `canUseFeature` method returns `true` or `false` depending on multiple facto
 $user->subscription('main')->canUseFeature('listings');
 ```
 
-Other feature methods on the user subscription instnace are:
+Other feature methods on the user subscription instance are:
 
 - `getFeatureUsage`: returns how many times the user has used a particular feature.
 - `getFeatureRemainings`: returns available uses for a particular feature.
@@ -181,7 +214,7 @@ Other feature methods on the user subscription instnace are:
 
 > All methods share the same signature: e.g. `$user->subscription('main')->getFeatureUsage('listings');`.
 
-### Record Feature Usage
+### Record Feature Usage<a name="record-feature-usage"></a>
 
 In order to effectively use the ability methods you will need to keep track of every usage of each feature (or at least those that require it). You may use the `recordFeatureUsage` method available through the user `subscription()` method:
 
@@ -189,7 +222,7 @@ In order to effectively use the ability methods you will need to keep track of e
 $user->subscription('main')->recordFeatureUsage('listings');
 ```
 
-The `recordFeatureUsage` method accept 3 parameters: the first one is the feature's name, the second one is the quantity of uses to add (default is `1`), and the third one indicates if the addition should be incremental (default behavior), when disabled the usage will be override by the quantity provided. E.g.:
+The `recordFeatureUsage` method accepts 3 parameters: the first one is the feature's name, the second one is the quantity of uses to add (default is `1`), and the third one indicates if the addition should be incremental (default behavior), when disabled the usage will be override by the quantity provided. E.g.:
 
 ```php
 // Increment by 2
@@ -199,7 +232,7 @@ $user->subscription('main')->recordFeatureUsage('listings', 2);
 $user->subscription('main')->recordFeatureUsage('listings', 9, false);
 ```
 
-### Reduce Feature Usage
+### Reduce Feature Usage<a name="reduce-feature-usage"></a>
 
 Reducing the feature usage is _almost_ the same as incrementing it. Here we only _substract_ a given quantity (default is `1`) to the actual usage:
 
@@ -207,13 +240,13 @@ Reducing the feature usage is _almost_ the same as incrementing it. Here we only
 $user->subscription('main')->reduceFeatureUsage('listings', 2);
 ```
 
-### Clear The Subscription Usage Data
+### Clear the Subscription Usage data<a name="clear-subscription-usage-data"></a>
 
 ```php
 $user->subscription('main')->usage()->delete();
 ```
 
-### Check Subscription Status
+### Check Subscription status<a name="check-subscription-status"></a>
 
 For a subscription to be considered active _one of the following must be `true`_:
 
@@ -235,7 +268,7 @@ $user->subscription('main')->onTrial();
 
 > Canceled subscriptions with an active trial or `ends_at` in the future are considered active.
 
-### Renew a Subscription
+### Renew a Subscription<a name="renew-subscription"></a>
 
 To renew a subscription you may use the `renew` method available in the subscription model. This will set a new `ends_at` date based on the selected plan and _will clear the usage data_ of the subscription.
 
@@ -245,7 +278,7 @@ $user->subscription('main')->renew();
 
 _Canceled subscriptions with an ended period can't be renewed._
 
-### Cancel a Subscription
+### Cancel a Subscription<a name="cancel-subscription"></a>
 
 To cancel a subscription, simply use the `cancel` method on the user's subscription:
 
@@ -259,9 +292,9 @@ By default the subscription will remain active until the end of the period, you 
 $user->subscription('main')->cancel(true);
 ```
 
-### Scopes
+### Scopes<a name="scopes"></a>
 
-#### Subscription Model
+#### Subscription Model<a name="subscription-model"></a>
 
 ```php
 // Get subscriptions by plan
@@ -284,7 +317,7 @@ $subscriptions = app('rinvex.subscriptions.plan_subscription')->findEndingPeriod
 $subscriptions = app('rinvex.subscriptions.plan_subscription')->findEndedPeriod()->get();
 ```
 
-### Models
+### Models<a name="models"></a>
 
 **Rinvex Subscriptions** uses 4 models:
 
@@ -294,14 +327,137 @@ Rinvex\Subscriptions\Models\PlanFeature;
 Rinvex\Subscriptions\Models\PlanSubscription;
 Rinvex\Subscriptions\Models\PlanSubscriptionUsage;
 ```
+## Migrating versions<a name="migrating"></a>
+### v4.x to v5.x<a name="migrating-4-to-5"></a>
+Version 5 introduces breaking changes.
+#### Create a Plan and Plan Features
+**Before**
+```php
+$plan = app('rinvex.subscriptions.plan')->create([
+    'name' => 'Pro',
+    'description' => 'Pro plan',
+    ...
+]);
 
+// Create multiple plan features at once
+$plan->features()->saveMany([
+    new PlanFeature(['name' => 'listings', 'value' => 50, 'sort_order' => 1]),
+    ...
+]);
+```
+**Now**
+Creating a plan now includes `tag` field that is unique. Features also include `tag` (this is an unique composite index, meaning only one feature `tag` is allowed per user and user type). As per old documentation, your `name` field would be your new `tag`. `name` would be a text name, and `description` remains unchanged.
+```php
+$plan = app('rinvex.subscriptions.plan')->create([
+    'tag' => 'pro',
+    'name' => 'Pro',
+    'description' => 'Pro plan',
+    ...
+]);
 
-## Changelog
+// Create multiple plan features at once
+$plan->features()->saveMany([
+    new PlanFeature(['tag' => 'listings', 'name' => 'Listings', 'description' => 'Number of house listings', 'value' => 50, 'sort_order' => 1]),
+    ...
+]);
+```
+#### New subscription
+**Before**
+```php
+$user->newSubscription('main', $plan);
+```
+**Now**
+```php
+$user->newSubscription('main', $plan, 'Main subscription');
+```
+#### Database migration
+##### Plans
+```php
+/**
+ * Run the migrations.
+ *
+ * @return void
+ */
+public function up()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plans'), function (Blueprint $table) {
+        $table->string('tag')->unique()->after('id');
+    });
+}
+
+/**
+ * Reverse the migrations.
+ *
+ * @return void
+ */
+public function down()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plans'), function (Blueprint $table) {
+        $table->dropColumn('tag');
+    });
+}
+```
+##### Plan Features
+```php
+/**
+ * Run the migrations.
+ *
+ * @return void
+ */
+public function up()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plan_features'), function (Blueprint $table) {
+        $table->string('tag')->after('id');
+        $table->unique(['tag', 'plan_id']);
+    });
+}
+
+/**
+ * Reverse the migrations.
+ *
+ * @return void
+ */
+public function down()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plan_features'), function (Blueprint $table) {
+        $table->dropColumn('tag');
+    });
+}
+```
+##### Plan Subscriptions
+```php
+/**
+ * Run the migrations.
+ *
+ * @return void
+ */
+public function up()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plan_subscriptions'), function (Blueprint $table) {
+        $table->string('tag')->after('id');
+        $table->unique(['tag', 'user_id', 'user_type']);
+    });
+}
+
+/**
+ * Reverse the migrations.
+ *
+ * @return void
+ */
+public function down()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plan_subscriptions'), function (Blueprint $table) {
+        $table->dropColumn('tag');
+    });
+}
+```
+
+## Changelog<a name="changelog"></a>
 
 Refer to the [Changelog](CHANGELOG.md) for a full history of the project.
 
 
-## Support
+## Support<a name="support"></a>
 
 The following support channels are available at your fingertips:
 
@@ -310,7 +466,7 @@ The following support channels are available at your fingertips:
 - [Follow on Twitter](https://twitter.com/rinvex)
 
 
-## Contributing & Protocols
+## Contributing & Protocols<a name="contributing"></a>
 
 Thank you for considering contributing to this project! The contribution guide can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -323,17 +479,17 @@ Bug reports, feature requests, and pull requests are very welcome.
 - [Git Flow](CONTRIBUTING.md#git-flow)
 
 
-## Security Vulnerabilities
+## Security Vulnerabilities<a name="security-vulnerabilities"></a>
 
 If you discover a security vulnerability within this project, please send an e-mail to [help@rinvex.com](help@rinvex.com). All security vulnerabilities will be promptly addressed.
 
 
-## About Rinvex
+## About Rinvex<a name="about-rinvex"></a>
 
 Rinvex is a software solutions startup, specialized in integrated enterprise solutions for SMEs established in Alexandria, Egypt since June 2016. We believe that our drive The Value, The Reach, and The Impact is what differentiates us and unleash the endless possibilities of our philosophy through the power of software. We like to call it Innovation At The Speed Of Life. That’s how we do our share of advancing humanity.
 
 
-## License
+## License<a name="license"></a>
 
 This software is released under [The MIT License (MIT)](LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,33 @@ public function down()
     });
 }
 ```
+##### Plans subscription usage
+This is a minor change.
+```php
+/**
+ * Run the migrations.
+ *
+ * @return void
+ */
+public function up()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plan_subscription_usage'), function (Blueprint $table) {
+        $table->integer('used')->unsigned()->change();
+    });
+}
+
+/**
+ * Reverse the migrations.
+ *
+ * @return void
+ */
+public function down()
+{
+    Schema::table(config('rinvex.subscriptions.tables.plan_subscription_usage'), function (Blueprint $table) {
+        $table->smallInteger('used')->unsigned()->change();
+    });
+}
+```
 
 ## Changelog<a name="changelog"></a>
 

--- a/database/migrations/2020_08_01_000001_create_plans_table.php
+++ b/database/migrations/2020_08_01_000001_create_plans_table.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreatePlansTable extends Migration
 {

--- a/database/migrations/2020_08_01_000002_create_plan_features_table.php
+++ b/database/migrations/2020_08_01_000002_create_plan_features_table.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreatePlanFeaturesTable extends Migration
 {

--- a/database/migrations/2020_08_01_000003_create_plan_subscriptions_table.php
+++ b/database/migrations/2020_08_01_000003_create_plan_subscriptions_table.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreatePlanSubscriptionsTable extends Migration
 {

--- a/database/migrations/2020_08_01_000004_create_plan_subscription_usage_table.php
+++ b/database/migrations/2020_08_01_000004_create_plan_subscription_usage_table.php
@@ -18,7 +18,7 @@ class CreatePlanSubscriptionUsageTable extends Migration
             $table->increments('id');
             $table->integer('subscription_id')->unsigned();
             $table->integer('feature_id')->unsigned();
-            $table->smallInteger('used')->unsigned();
+            $table->integer('used')->unsigned();
             $table->dateTime('valid_until')->nullable();
             $table->string('timezone')->nullable();
             $table->timestamps();

--- a/database/migrations/2020_08_01_000004_create_plan_subscription_usage_table.php
+++ b/database/migrations/2020_08_01_000004_create_plan_subscription_usage_table.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreatePlanSubscriptionUsageTable extends Migration
 {

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -238,7 +238,7 @@ class Plan extends Model implements Sortable
      */
     public function isFree(): bool
     {
-        return (float)$this->price <= 0.00;
+        return (float) $this->price <= 0.00;
     }
 
     /**

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Rinvex\Subscriptions\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Rinvex\Support\Traits\HasSlug;
-use Rinvex\Support\Traits\HasTranslations;
-use Rinvex\Support\Traits\ValidatingTrait;
-use Spatie\EloquentSortable\Sortable;
-use Spatie\EloquentSortable\SortableTrait;
 use Spatie\Sluggable\SlugOptions;
+use Rinvex\Support\Traits\HasSlug;
+use Spatie\EloquentSortable\Sortable;
+use Illuminate\Database\Eloquent\Model;
+use Rinvex\Support\Traits\HasTranslations;
+use Spatie\EloquentSortable\SortableTrait;
+use Rinvex\Support\Traits\ValidatingTrait;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * Rinvex\Subscriptions\Models\Plan.
@@ -176,8 +176,8 @@ class Plan extends Model implements Sortable
 
         $this->setTable(config('rinvex.subscriptions.tables.plans'));
         $this->setRules([
-            'tag' => 'required|max:150|unique:' . config('rinvex.subscriptions.tables.plans') . ',tag',
-            'slug' => 'required|alpha_dash|max:150|unique:' . config('rinvex.subscriptions.tables.plans') . ',slug',
+            'tag' => 'required|max:150|unique:'.config('rinvex.subscriptions.tables.plans').',tag',
+            'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plans').',slug',
             'name' => 'required|string|strip_tags|max:150',
             'description' => 'nullable|string|max:32768',
             'is_active' => 'sometimes|boolean',

--- a/src/Models/PlanFeature.php
+++ b/src/Models/PlanFeature.php
@@ -147,7 +147,7 @@ class PlanFeature extends Model implements Sortable
                 'max:150',
                 Rule::unique(config('rinvex.subscriptions.tables.plan_features'))->where(function ($query) {
                     return $query->where('id', '!=', $this->id)->where('plan_id', $this->plan_id);
-                })
+                }),
             ],
             'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
             'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_features').',slug',

--- a/src/Models/PlanFeature.php
+++ b/src/Models/PlanFeature.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Rinvex\Subscriptions\Models;
 
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Validation\Rule;
-use Rinvex\Subscriptions\Services\Period;
-use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Spatie\Sluggable\SlugOptions;
 use Rinvex\Support\Traits\HasSlug;
+use Spatie\EloquentSortable\Sortable;
+use Illuminate\Database\Eloquent\Model;
+use Rinvex\Subscriptions\Services\Period;
 use Rinvex\Support\Traits\HasTranslations;
 use Rinvex\Support\Traits\ValidatingTrait;
-use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
-use Spatie\Sluggable\SlugOptions;
+use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * Rinvex\Subscriptions\Models\PlanFeature.
@@ -142,11 +142,15 @@ class PlanFeature extends Model implements Sortable
 
         $this->setTable(config('rinvex.subscriptions.tables.plan_features'));
         $this->setRules([
-            'tag' => ['required', 'max:150', Rule::unique(config('rinvex.subscriptions.tables.plan_features'))->where(function ($query) {
-                return $query->where('id', '!=', $this->id)->where('plan_id', $this->plan_id);
-            })],
-            'plan_id' => 'required|integer|exists:' . config('rinvex.subscriptions.tables.plans') . ',id',
-            'slug' => 'required|alpha_dash|max:150|unique:' . config('rinvex.subscriptions.tables.plan_features') . ',slug',
+            'tag' => [
+                'required',
+                'max:150',
+                Rule::unique(config('rinvex.subscriptions.tables.plan_features'))->where(function ($query) {
+                    return $query->where('id', '!=', $this->id)->where('plan_id', $this->plan_id);
+                })
+            ],
+            'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
+            'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_features').',slug',
             'name' => 'required|string|strip_tags|max:150',
             'description' => 'nullable|string|max:32768',
             'value' => 'required|string',

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -161,7 +161,7 @@ class PlanSubscription extends Model
                 }),
             ],
             'name' => 'required|string|strip_tags|max:150',
-            'description' => 'nullable|string|max:10000',
+            'description' => 'nullable|string|max:32768',
             'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_subscriptions').',slug',
             'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
             'user_id' => 'required|integer',

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Rinvex\Subscriptions\Models;
 
-use Carbon\Carbon;
 use DB;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Validation\Rule;
+use Carbon\Carbon;
 use LogicException;
-use Rinvex\Subscriptions\Services\Period;
-use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Illuminate\Validation\Rule;
+use Spatie\Sluggable\SlugOptions;
 use Rinvex\Support\Traits\HasSlug;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Rinvex\Subscriptions\Services\Period;
 use Rinvex\Support\Traits\HasTranslations;
 use Rinvex\Support\Traits\ValidatingTrait;
-use Spatie\Sluggable\SlugOptions;
+use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
  * Rinvex\Subscriptions\Models\PlanSubscription.
@@ -151,13 +151,19 @@ class PlanSubscription extends Model
 
         $this->setTable(config('rinvex.subscriptions.tables.plan_subscriptions'));
         $this->setRules([
-            'tag' => ['required', 'alpha_dash', 'max:150', Rule::unique(config('rinvex.subscriptions.tables.plan_subscriptions'))->where(function ($query) {
-                return $query->where('id', '!=', $this->id)->where('user_type', $this->user_type)->where('user_id', $this->user_id);
-            })],
+            'tag' => [
+                'required',
+                'alpha_dash',
+                'max:150',
+                Rule::unique(config('rinvex.subscriptions.tables.plan_subscriptions'))->where(function ($query) {
+                    return $query->where('id', '!=', $this->id)->where('user_type', $this->user_type)->where('user_id',
+                        $this->user_id);
+                })
+            ],
             'name' => 'required|string|strip_tags|max:150',
             'description' => 'nullable|string|max:10000',
-            'slug' => 'required|alpha_dash|max:150|unique:' . config('rinvex.subscriptions.tables.plan_subscriptions') . ',slug',
-            'plan_id' => 'required|integer|exists:' . config('rinvex.subscriptions.tables.plans') . ',id',
+            'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_subscriptions').',slug',
+            'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
             'user_id' => 'required|integer',
             'user_type' => 'required|string|strip_tags|max:150',
             'trial_ends_at' => 'nullable|date',
@@ -176,7 +182,7 @@ class PlanSubscription extends Model
         parent::boot();
 
         static::validating(function (self $model) {
-            if (!$model->starts_at || !$model->ends_at) {
+            if (! $model->starts_at || ! $model->ends_at) {
                 $model->setNewPeriod();
             }
         });
@@ -222,7 +228,7 @@ class PlanSubscription extends Model
      */
     public function active(): bool
     {
-        return !$this->ended() || $this->onTrial();
+        return ! $this->ended() || $this->onTrial();
     }
 
     /**
@@ -232,7 +238,7 @@ class PlanSubscription extends Model
      */
     public function inactive(): bool
     {
-        return !$this->active();
+        return ! $this->active();
     }
 
     /**
@@ -442,8 +448,11 @@ class PlanSubscription extends Model
      *
      * @return \Rinvex\Subscriptions\Models\PlanSubscriptionUsage
      */
-    public function recordFeatureUsage(string $featureTag, int $uses = 1, bool $incremental = true): PlanSubscriptionUsage
-    {
+    public function recordFeatureUsage(
+        string $featureTag,
+        int $uses = 1,
+        bool $incremental = true
+    ): PlanSubscriptionUsage {
         $feature = $this->plan->features()->where('tag', $featureTag)->first();
 
         $usage = $this->usage()->firstOrNew([
@@ -532,7 +541,7 @@ class PlanSubscription extends Model
     {
         $usage = $this->usage()->byFeatureTag($featureTag)->first();
 
-        return !$usage->expired() ? $usage->used : 0;
+        return ! $usage->expired() ? $usage->used : 0;
     }
 
     /**

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -156,9 +156,9 @@ class PlanSubscription extends Model
                 'alpha_dash',
                 'max:150',
                 Rule::unique(config('rinvex.subscriptions.tables.plan_subscriptions'))->where(function ($query) {
-                    return $query->where('id', '!=', $this->id)->where('user_type', $this->user_type)->where('user_id',
-                        $this->user_id);
-                })
+                    return $query->where('id', '!=', $this->id)->where('user_type', $this->user_type)
+                        ->where('user_id', $this->user_id);
+                }),
             ],
             'name' => 'required|string|strip_tags|max:150',
             'description' => 'nullable|string|max:10000',
@@ -319,9 +319,9 @@ class PlanSubscription extends Model
     /**
      * Renew subscription period.
      *
-     * @return $this
      * @throws \LogicException
      *
+     * @return $this
      */
     public function renew()
     {
@@ -417,7 +417,7 @@ class PlanSubscription extends Model
      * Set new subscription period.
      *
      * @param string $invoice_interval
-     * @param int    $invoice_period
+     * @param string $invoice_period
      * @param string $start
      *
      * @return $this

--- a/src/Models/PlanSubscriptionUsage.php
+++ b/src/Models/PlanSubscriptionUsage.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Rinvex\Subscriptions\Models;
 
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Builder;
 use Rinvex\Support\Traits\ValidatingTrait;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * Rinvex\Subscriptions\Models\PlanSubscriptionUsage.
@@ -94,8 +94,8 @@ class PlanSubscriptionUsage extends Model
 
         $this->setTable(config('rinvex.subscriptions.tables.plan_subscription_usage'));
         $this->setRules([
-            'subscription_id' => 'required|integer|exists:' . config('rinvex.subscriptions.tables.plan_subscriptions') . ',id',
-            'feature_id' => 'required|integer|exists:' . config('rinvex.subscriptions.tables.plan_features') . ',id',
+            'subscription_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plan_subscriptions').',id',
+            'feature_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plan_features').',id',
             'used' => 'required|integer',
             'valid_until' => 'nullable|date',
         ]);
@@ -118,7 +118,8 @@ class PlanSubscriptionUsage extends Model
      */
     public function subscription(): BelongsTo
     {
-        return $this->belongsTo(config('rinvex.subscriptions.models.plan_subscription'), 'subscription_id', 'id', 'subscription');
+        return $this->belongsTo(config('rinvex.subscriptions.models.plan_subscription'), 'subscription_id', 'id',
+            'subscription');
     }
 
     /**

--- a/src/Models/PlanSubscriptionUsage.php
+++ b/src/Models/PlanSubscriptionUsage.php
@@ -118,8 +118,12 @@ class PlanSubscriptionUsage extends Model
      */
     public function subscription(): BelongsTo
     {
-        return $this->belongsTo(config('rinvex.subscriptions.models.plan_subscription'), 'subscription_id', 'id',
-            'subscription');
+        return $this->belongsTo(
+            config('rinvex.subscriptions.models.plan_subscription'),
+            'subscription_id',
+            'id',
+            'subscription'
+        );
     }
 
     /**

--- a/src/Providers/SubscriptionsServiceProvider.php
+++ b/src/Providers/SubscriptionsServiceProvider.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Rinvex\Subscriptions\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use Rinvex\Subscriptions\Console\Commands\MigrateCommand;
-use Rinvex\Subscriptions\Console\Commands\PublishCommand;
-use Rinvex\Subscriptions\Console\Commands\RollbackCommand;
 use Rinvex\Subscriptions\Models\Plan;
+use Illuminate\Support\ServiceProvider;
+use Rinvex\Support\Traits\ConsoleTools;
 use Rinvex\Subscriptions\Models\PlanFeature;
 use Rinvex\Subscriptions\Models\PlanSubscription;
 use Rinvex\Subscriptions\Models\PlanSubscriptionUsage;
-use Rinvex\Support\Traits\ConsoleTools;
+use Rinvex\Subscriptions\Console\Commands\PublishCommand;
+use Rinvex\Subscriptions\Console\Commands\MigrateCommand;
+use Rinvex\Subscriptions\Console\Commands\RollbackCommand;
 
 class SubscriptionsServiceProvider extends ServiceProvider
 {
@@ -36,20 +36,27 @@ class SubscriptionsServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->mergeConfigFrom(realpath(__DIR__ . '/../../config/config.php'), 'rinvex.subscriptions');
+        $this->mergeConfigFrom(realpath(__DIR__.'/../../config/config.php'), 'rinvex.subscriptions');
 
         // Bind eloquent models to IoC container
-        $this->app->singleton('rinvex.subscriptions.plan', $planModel = $this->app['config']['rinvex.subscriptions.models.plan']);
+        $this->app->singleton('rinvex.subscriptions.plan',
+            $planModel = $this->app['config']['rinvex.subscriptions.models.plan']);
         $planModel === Plan::class || $this->app->alias('rinvex.subscriptions.plan', Plan::class);
 
-        $this->app->singleton('rinvex.subscriptions.plan_feature', $planFeatureModel = $this->app['config']['rinvex.subscriptions.models.plan_feature']);
-        $planFeatureModel === PlanFeature::class || $this->app->alias('rinvex.subscriptions.plan_feature', PlanFeature::class);
+        $this->app->singleton('rinvex.subscriptions.plan_feature',
+            $planFeatureModel = $this->app['config']['rinvex.subscriptions.models.plan_feature']);
+        $planFeatureModel === PlanFeature::class || $this->app->alias('rinvex.subscriptions.plan_feature',
+            PlanFeature::class);
 
-        $this->app->singleton('rinvex.subscriptions.plan_subscription', $planSubscriptionModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription']);
-        $planSubscriptionModel === PlanSubscription::class || $this->app->alias('rinvex.subscriptions.plan_subscription', PlanSubscription::class);
+        $this->app->singleton('rinvex.subscriptions.plan_subscription',
+            $planSubscriptionModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription']);
+        $planSubscriptionModel === PlanSubscription::class || $this->app->alias('rinvex.subscriptions.plan_subscription',
+            PlanSubscription::class);
 
-        $this->app->singleton('rinvex.subscriptions.plan_subscription_usage', $planSubscriptionUsageModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription_usage']);
-        $planSubscriptionUsageModel === PlanSubscriptionUsage::class || $this->app->alias('rinvex.subscriptions.plan_subscription_usage', PlanSubscriptionUsage::class);
+        $this->app->singleton('rinvex.subscriptions.plan_subscription_usage',
+            $planSubscriptionUsageModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription_usage']);
+        $planSubscriptionUsageModel === PlanSubscriptionUsage::class || $this->app->alias('rinvex.subscriptions.plan_subscription_usage',
+            PlanSubscriptionUsage::class);
 
         // Register console commands
         $this->registerCommands($this->commands);
@@ -65,6 +72,6 @@ class SubscriptionsServiceProvider extends ServiceProvider
         // Publish Resources
         $this->publishesConfig('rinvex/laravel-subscriptions');
         $this->publishesMigrations('rinvex/laravel-subscriptions');
-        !$this->autoloadMigrations('rinvex/laravel-subscriptions') || $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        ! $this->autoloadMigrations('rinvex/laravel-subscriptions') || $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
     }
 }

--- a/src/Providers/SubscriptionsServiceProvider.php
+++ b/src/Providers/SubscriptionsServiceProvider.php
@@ -10,8 +10,8 @@ use Rinvex\Support\Traits\ConsoleTools;
 use Rinvex\Subscriptions\Models\PlanFeature;
 use Rinvex\Subscriptions\Models\PlanSubscription;
 use Rinvex\Subscriptions\Models\PlanSubscriptionUsage;
-use Rinvex\Subscriptions\Console\Commands\PublishCommand;
 use Rinvex\Subscriptions\Console\Commands\MigrateCommand;
+use Rinvex\Subscriptions\Console\Commands\PublishCommand;
 use Rinvex\Subscriptions\Console\Commands\RollbackCommand;
 
 class SubscriptionsServiceProvider extends ServiceProvider
@@ -39,23 +39,32 @@ class SubscriptionsServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(realpath(__DIR__.'/../../config/config.php'), 'rinvex.subscriptions');
 
         // Bind eloquent models to IoC container
-        $this->app->singleton('rinvex.subscriptions.plan',
-            $planModel = $this->app['config']['rinvex.subscriptions.models.plan']);
+        $this->app->singleton(
+            'rinvex.subscriptions.plan',
+            $planModel = $this->app['config']['rinvex.subscriptions.models.plan']
+        );
         $planModel === Plan::class || $this->app->alias('rinvex.subscriptions.plan', Plan::class);
 
         $this->app->singleton('rinvex.subscriptions.plan_feature',
             $planFeatureModel = $this->app['config']['rinvex.subscriptions.models.plan_feature']);
-        $planFeatureModel === PlanFeature::class || $this->app->alias('rinvex.subscriptions.plan_feature',
+        $planFeatureModel === PlanFeature::class || $this->app->alias(
+            'rinvex.subscriptions.plan_feature',
             PlanFeature::class);
 
-        $this->app->singleton('rinvex.subscriptions.plan_subscription',
-            $planSubscriptionModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription']);
-        $planSubscriptionModel === PlanSubscription::class || $this->app->alias('rinvex.subscriptions.plan_subscription',
+        $this->app->singleton(
+            'rinvex.subscriptions.plan_subscription',
+            $planSubscriptionModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription']
+        );
+        $planSubscriptionModel === PlanSubscription::class || $this->app->alias(
+            'rinvex.subscriptions.plan_subscription',
             PlanSubscription::class);
 
-        $this->app->singleton('rinvex.subscriptions.plan_subscription_usage',
-            $planSubscriptionUsageModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription_usage']);
-        $planSubscriptionUsageModel === PlanSubscriptionUsage::class || $this->app->alias('rinvex.subscriptions.plan_subscription_usage',
+        $this->app->singleton(
+            'rinvex.subscriptions.plan_subscription_usage',
+            $planSubscriptionUsageModel = $this->app['config']['rinvex.subscriptions.models.plan_subscription_usage']
+        );
+        $planSubscriptionUsageModel === PlanSubscriptionUsage::class || $this->app->alias(
+            'rinvex.subscriptions.plan_subscription_usage',
             PlanSubscriptionUsage::class);
 
         // Register console commands

--- a/src/Services/Period.php
+++ b/src/Services/Period.php
@@ -51,7 +51,7 @@ class Period
 
         if (empty($start)) {
             $this->start = Carbon::now();
-        } elseif (!$start instanceof Carbon) {
+        } elseif (! $start instanceof Carbon) {
             $this->start = new Carbon($start);
         } else {
             $this->start = $start;
@@ -62,7 +62,7 @@ class Period
         }
 
         $start = clone $this->start;
-        $method = 'add' . ucfirst($this->interval) . 's';
+        $method = 'add'.ucfirst($this->interval).'s';
         $this->end = $start->{$method}($this->period);
     }
 

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rinvex\Subscriptions\Traits;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Rinvex\Subscriptions\Models\Plan;
-use Rinvex\Subscriptions\Models\PlanSubscription;
 use Rinvex\Subscriptions\Services\Period;
+use Illuminate\Database\Eloquent\Collection;
+use Rinvex\Subscriptions\Models\PlanSubscription;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait HasSubscriptions
 {


### PR DESCRIPTION
Hello,

I propose this changes that would solve PR #76 and issue #109 . **These are breaking changes**, so I included in README.md instructions on how to migrate from v4.x and also changed documentation code. This PR would be v5.0

The big change included in package is the addition of a column named "tag" in Plan, PlanSubscription and PlanFeature. This tag is a non translatable string, so it's independent from language unlike slug. 
Why I introduce this change? Because  many parts of the package functionality referenced in the docs are not that useful if slug it's generated and we do not know the value beforehand and cannot reuse code like in `$user->subscription('main')`, because every user has a different subscription slug, so having that coded makes no sense.

In Plan it's just unique.
In Plan Subscription it's unique to each user entity.
In Plan Feature it's unique to each plan.

This has been tested as new install and also as migrated from v4.

Hope you find this as useful as I do.

Thanks for your attention