### PR TITLE
Add missing trait and use config model

### DIFF
--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Rinvex\Subscriptions\Models;
 
-use Spatie\Sluggable\SlugOptions;
-use Rinvex\Support\Traits\HasSlug;
-use Spatie\EloquentSortable\Sortable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Rinvex\Support\Traits\HasSlug;
 use Rinvex\Support\Traits\HasTranslations;
 use Rinvex\Support\Traits\ValidatingTrait;
+use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Sluggable\SlugOptions;
 
 /**
  * Rinvex\Subscriptions\Models\Plan.
@@ -72,6 +73,7 @@ class Plan extends Model implements Sortable
     use SortableTrait;
     use HasTranslations;
     use ValidatingTrait;
+    use SoftDeletes;
 
     /**
      * {@inheritdoc}

--- a/src/Models/PlanFeature.php
+++ b/src/Models/PlanFeature.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Rinvex\Subscriptions\Models;
 
 use Carbon\Carbon;
-use Spatie\Sluggable\SlugOptions;
-use Rinvex\Support\Traits\HasSlug;
-use Spatie\EloquentSortable\Sortable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Rinvex\Subscriptions\Services\Period;
+use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Rinvex\Support\Traits\HasSlug;
 use Rinvex\Support\Traits\HasTranslations;
 use Rinvex\Support\Traits\ValidatingTrait;
+use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
-use Rinvex\Subscriptions\Traits\BelongsToPlan;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Sluggable\SlugOptions;
 
 /**
  * Rinvex\Subscriptions\Models\PlanFeature.
@@ -57,6 +58,7 @@ class PlanFeature extends Model implements Sortable
     use SortableTrait;
     use HasTranslations;
     use ValidatingTrait;
+    use SoftDeletes;
 
     /**
      * {@inheritdoc}

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Rinvex\Subscriptions\Models;
 
-use DB;
 use Carbon\Carbon;
-use LogicException;
-use Spatie\Sluggable\SlugOptions;
-use Rinvex\Support\Traits\HasSlug;
-use Illuminate\Database\Eloquent\Model;
+use DB;
 use Illuminate\Database\Eloquent\Builder;
-use Rinvex\Subscriptions\Services\Period;
-use Rinvex\Support\Traits\HasTranslations;
-use Rinvex\Support\Traits\ValidatingTrait;
-use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use LogicException;
+use Rinvex\Subscriptions\Services\Period;
+use Rinvex\Subscriptions\Traits\BelongsToPlan;
+use Rinvex\Support\Traits\HasSlug;
+use Rinvex\Support\Traits\HasTranslations;
+use Rinvex\Support\Traits\ValidatingTrait;
+use Spatie\Sluggable\SlugOptions;
 
 /**
  * Rinvex\Subscriptions\Models\PlanSubscription.
@@ -69,6 +70,7 @@ class PlanSubscription extends Model
     use BelongsToPlan;
     use HasTranslations;
     use ValidatingTrait;
+    use SoftDeletes;
 
     /**
      * {@inheritdoc}

--- a/src/Models/PlanSubscriptionUsage.php
+++ b/src/Models/PlanSubscriptionUsage.php
@@ -133,7 +133,7 @@ class PlanSubscriptionUsage extends Model
      */
     public function scopeByFeatureSlug(Builder $builder, string $featureSlug): Builder
     {
-        $feature = PlanFeature::where('slug', $featureSlug)->first();
+        $feature = config('rinvex.subscriptions.models.plan_feature')::where('slug', $featureSlug)->first();
 
         return $builder->where('feature_id', $feature->getKey() ?? null);
     }

--- a/src/Models/PlanSubscriptionUsage.php
+++ b/src/Models/PlanSubscriptionUsage.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Rinvex\Subscriptions\Models;
 
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Rinvex\Support\Traits\ValidatingTrait;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Rinvex\Support\Traits\ValidatingTrait;
 
 /**
  * Rinvex\Subscriptions\Models\PlanSubscriptionUsage.
@@ -38,6 +39,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class PlanSubscriptionUsage extends Model
 {
     use ValidatingTrait;
+    use SoftDeletes;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
1. Migrations have `$table->softDeletes();` but models don't have `SoftDeletes` trait
2. [PlanSubscriptionUsage](https://github.com/rinvex/laravel-subscriptions/blob/037bfd59727a519ca63f2e438779b3e8e0b9ebb7/src/Models/PlanSubscriptionUsage.php#L134) uses hardcoded model instead of the one defined in config