### PR TITLE
Feature to find active subscriptions for a user

### DIFF
--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -413,7 +413,7 @@ class PlanSubscription extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    function scopeFindActive(Builder $builder): Builder
+    public function scopeFindActive(Builder $builder): Builder
     {
         return $builder->where('ends_at', '>', now());
     }

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -407,6 +407,18 @@ class PlanSubscription extends Model
     }
 
     /**
+     * Scope all active subscriptions for a user.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    function scopeFindActive(Builder $builder): Builder
+    {
+        return $builder->where('ends_at', '>', now());
+    }
+
+    /**
      * Set new subscription period.
      *
      * @param string $invoice_interval


### PR DESCRIPTION
i have been using this feature for a while through extending the main PlanSubscription model on my project but I thought it's a necessary feature to have in the original package since we have a similar feature that shows expired and so on. 

Usage example:
`$activeSubscriptions = app('rinvex.subscriptions.plan_subscription')->ofSubscriber($user)->findActive()->get();`